### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -1019,7 +1019,12 @@ async def download_direct(
     operations = [op.model_dump() for op in request.operations]
     
     # For PDF input, force image output since ImageMagick rasterizes PDFs
-    actual_output_format = request.output_format
+    allowed_formats = {"webp", "png", "jpg", "jpeg", "gif"}
+    # Validate and sanitize output_format
+    requested_format = request.output_format.lower().strip()
+    if requested_format not in allowed_formats:
+        raise HTTPException(status_code=400, detail="Invalid output format")
+    actual_output_format = requested_format
     is_pdf_input = validated_input_path.lower().endswith('.pdf') or (image.mime_type and 'pdf' in image.mime_type.lower())
     if is_pdf_input:
         actual_output_format = 'png'  # PDF is rasterized, output as PNG


### PR DESCRIPTION
Potential fix for [https://github.com/PrzemekSkw/imagemagick-webui/security/code-scanning/13](https://github.com/PrzemekSkw/imagemagick-webui/security/code-scanning/13)

The best approach is to rigorously sanitize and validate the `output_format` field before using it in any filesystem path. 
- Restrict `output_format` strictly to safe, expected values (for example, allowing only `"webp"`, `"png"`, `"jpg"`, `"jpeg"`, `"gif"`).
- Reject it, or replace it with a default, if it does not match the allowed set.
- This prevents any traversal attacks or injection of dangerous characters via the extension, so the path built with tempfile remains safe.
- The validation should happen just before `actual_output_format` is used for path construction, ideally _before_ line 1032.
- You can hard-code the allowed list, matching those in the `mime_types` dictionary.

Implement this by:
- Defining a set/list of allowed output formats.
- Lowercasing/normalizing the input.
- Validating, and if invalid, either raise a 400 error or use a default safe value.

No other methods/imports are required beyond already-imported types.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
