### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -1035,17 +1035,22 @@ async def download_direct(
     
     # Use temp directory for output (already in allowed dirs)
     output_path = os.path.join(tempfile.gettempdir(), f"download_{uuid.uuid4().hex}.{actual_output_format}")
-    
+    # Defensive normalization and containment check
+    secured_output_path = os.path.normpath(os.path.abspath(output_path))
+    tmpdir = os.path.abspath(tempfile.gettempdir())
+    if not secured_output_path.startswith(tmpdir + os.sep):
+        raise HTTPException(status_code=400, detail="Output path is invalid.")
+
     # Build and execute command
     command = await imagemagick_service.build_command(
         validated_input_path,
-        output_path,
+        secured_output_path,
         operations
     )
     
     success, stdout, stderr = await imagemagick_service.execute(command)
-    
-    if not success or not Path(output_path).exists():
+
+    if not success or not Path(secured_output_path).exists():
         raise HTTPException(status_code=500, detail=f"Processing failed: {stderr}")
     
     # Get MIME type
@@ -1060,7 +1065,7 @@ async def download_direct(
     
     # Return file for download
     return FileResponse(
-        path=output_path,
+        path=secured_output_path,
         filename=output_filename,
         media_type=media_type,
         headers={


### PR DESCRIPTION
Potential fix for [https://github.com/PrzemekSkw/imagemagick-webui/security/code-scanning/12](https://github.com/PrzemekSkw/imagemagick-webui/security/code-scanning/12)

To mitigate any potential, now or in the future, for user influence over file paths, we should normalize the generated `output_path` using `os.path.normpath` and check it is inside the intended temporary directory, analogous to the "good" example in the background section. This should be done before using the path in the vulnerable sinks (checking for file existence and passing to `FileResponse`). This fix should be placed after `output_path` is constructed, and preferably, the normalized version should then be used in all subsequent file system interactions. 

Necessary actions:
- After constructing `output_path`, get the absolute path and check that it starts with the intended temp directory.
- If not, raise an appropriate HTTPException.
- Use the normalized path for downstream actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
