### PR TITLE
GPU support for background removal (v1.1.0)

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,143 @@
+# ============================================
+# Dockerfile.gpu — GPU-enabled build (latest-gpu)
+# CPU "latest" stays light; this image adds CUDA 12 + cuDNN 9 for rembg.
+# Base verified: onnxruntime-gpu (PyPI default CUDA 12.x since 1.19)
+# requires CUDA 12.* AND cuDNN 9.* — the -cudnn- tag bundles cuDNN 9.
+# ============================================
+
+# ---- STAGE 1: Frontend Builder (identical to CPU Dockerfile) ----
+FROM node:26-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+ARG NEXT_PUBLIC_API_PORT=8000
+ENV NEXT_PUBLIC_API_PORT=${NEXT_PUBLIC_API_PORT}
+
+COPY frontend/package.json ./
+RUN npm install --legacy-peer-deps
+
+COPY frontend/ ./
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+RUN npm run build
+
+# ---- STAGE 2: Python deps (CUDA base so onnxruntime-gpu links correctly) ----
+# CUDA 12.6 + cuDNN 9 runtime on Ubuntu 24.04 (Python 3.12 from deadsnakes).
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS python-deps
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Python 3.12 to match the CPU image exactly (onnxruntime supports <=3.12).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 \
+    python3.12-venv \
+    python3.12-dev \
+    gcc \
+    libpq-dev \
+    libmagic-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3.12 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# GPU requirements: same as CPU but swap onnxruntime -> onnxruntime-gpu.
+COPY backend/requirements-gpu.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements-gpu.txt
+
+# ---- STAGE 3: Final GPU production image ----
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04 AS production
+
+LABEL maintainer="ImageMagick WebGUI"
+LABEL description="GPU-enabled ImageMagick WebGUI (CUDA 12 + cuDNN 9, rembg/BiRefNet on GPU)"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    NODE_ENV=production \
+    NUMBA_CACHE_DIR=/tmp/numba_cache \
+    NUMBA_DISABLE_JIT=1 \
+    MPLCONFIGDIR=/tmp/matplotlib \
+    # Signal to the app that this image is GPU-capable.
+    GPU_ENABLED=true
+
+WORKDIR /app
+
+# Runtime deps: Python 3.12 + ImageMagick + Node 20 + tini.
+# NOTE: cuDNN 9 and CUDA 12 libs come from the base image — do NOT reinstall them.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 \
+    python3.12-venv \
+    imagemagick \
+    libmagickwand-dev \
+    ghostscript \
+    poppler-utils \
+    libpq5 \
+    libmagic1 \
+    curl \
+    tini \
+    ca-certificates \
+    gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Configure ImageMagick policy (identical to CPU image).
+RUN POLICY_FILE=$(find /etc -name "policy.xml" -path "*ImageMagick*" 2>/dev/null | head -1) && \
+    if [ -n "$POLICY_FILE" ] && [ -f "$POLICY_FILE" ]; then \
+    echo "Found policy file: $POLICY_FILE"; \
+    sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' "$POLICY_FILE"; \
+    sed -i 's/rights="none" pattern="PS"/rights="read|write" pattern="PS"/' "$POLICY_FILE"; \
+    sed -i 's/rights="none" pattern="EPS"/rights="read|write" pattern="EPS"/' "$POLICY_FILE"; \
+    sed -i 's/<policy domain="resource" name="memory" value="[^"]*"\/>/<policy domain="resource" name="memory" value="2GiB"\/>/' "$POLICY_FILE"; \
+    sed -i 's/<policy domain="resource" name="disk" value="[^"]*"\/>/<policy domain="resource" name="disk" value="4GiB"\/>/' "$POLICY_FILE"; \
+    sed -i 's/<policy domain="resource" name="width" value="[^"]*"\/>/<policy domain="resource" name="width" value="16KP"\/>/' "$POLICY_FILE"; \
+    sed -i 's/<policy domain="resource" name="height" value="[^"]*"\/>/<policy domain="resource" name="height" value="16KP"\/>/' "$POLICY_FILE"; \
+    fi
+
+RUN convert -version && identify -version
+
+COPY --from=python-deps /opt/venv /opt/venv
+
+COPY --from=frontend-builder /app/frontend/.next/standalone ./frontend/.next/standalone
+COPY --from=frontend-builder /app/frontend/.next/static ./frontend/.next/standalone/.next/static
+COPY --from=frontend-builder /app/frontend/public ./frontend/.next/standalone/public
+
+COPY backend/ ./backend/
+
+RUN groupadd -r appuser && useradd -r -g appuser -m -d /home/appuser appuser
+
+RUN mkdir -p /app/uploads /app/processed /tmp/imagemagick /tmp/numba_cache /tmp/matplotlib /home/appuser/.u2net && \
+    chown -R appuser:appuser /app /tmp/imagemagick /tmp/numba_cache /tmp/matplotlib /home/appuser
+
+ENV HOME=/home/appuser \
+    U2NET_HOME=/home/appuser/.u2net
+
+# Pre-download the default GPU model. BiRefNet-general gives the precise edges
+# that justify GPU; isnet kept as a lighter fallback.
+RUN python3.12 -c "from rembg import new_session; new_session('birefnet-general')" || echo "birefnet model download failed, will retry at runtime"
+RUN python3.12 -c "from rembg import new_session; new_session('isnet-general-use')" || echo "isnet model download failed, will retry at runtime"
+RUN chown -R appuser:appuser /home/appuser/.u2net || true
+
+COPY scripts/start.sh /start.sh
+RUN chmod +x /start.sh
+
+USER appuser
+
+EXPOSE 3000 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:3000/api/health && curl -f http://localhost:8000/health || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/start.sh"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -56,9 +56,12 @@ class Settings(BaseSettings):
     gpu_enabled: bool = False
     # Force CPU even on the GPU image (debugging / fallback). Overrides gpu_enabled.
     force_cpu: bool = False
-    # Per-session GPU memory cap (bytes) for the CUDA execution provider.
-    # 2 GiB matches the ImageMagick memory policy; tune per card.
-    cuda_gpu_mem_limit: int = 2 * 1024 * 1024 * 1024
+    # GPU memory arena cap (bytes) for the CUDA execution provider.
+    # 0 (default) = no fixed cap; onnxruntime grows the arena dynamically up to
+    # whatever the card has. Required for large models like BiRefNet — a low cap
+    # causes "Available memory of 0 is smaller than requested bytes". Set a
+    # positive value only to hard-cap the arena when sharing the card.
+    cuda_gpu_mem_limit: int = 0
     
     # Security
     rate_limit: str = "100/minute"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -50,6 +50,16 @@ class Settings(BaseSettings):
     # Set to a low number (e.g. 2) on shared/weak VPS to limit CPU usage.
     onnx_threads: int = 0
     
+    # AI / GPU acceleration (v1.1.0)
+    # Set to true automatically by Dockerfile.gpu (ENV GPU_ENABLED=true).
+    # On the CPU image this stays false and CUDA is never attempted.
+    gpu_enabled: bool = False
+    # Force CPU even on the GPU image (debugging / fallback). Overrides gpu_enabled.
+    force_cpu: bool = False
+    # Per-session GPU memory cap (bytes) for the CUDA execution provider.
+    # 2 GiB matches the ImageMagick memory policy; tune per card.
+    cuda_gpu_mem_limit: int = 2 * 1024 * 1024 * 1024
+    
     # Security
     rate_limit: str = "100/minute"
     require_login: bool = True  # If True, users must login to use the app
@@ -66,7 +76,7 @@ class Settings(BaseSettings):
     # History retention
     history_retention_hours: int = 24
     
-    @field_validator('require_login', 'allow_registration', mode='before')
+    @field_validator('require_login', 'allow_registration', 'gpu_enabled', 'force_cpu', mode='before')
     @classmethod
     def parse_bool(cls, v):
         """Parse boolean from various string formats"""

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,6 +1,7 @@
 """
 AI Service for intelligent image processing
-Includes background removal using rembg and upscaling
+Includes background removal using rembg and upscaling.
+Optional CUDA/GPU acceleration (v1.1.0).
 """
 
 import asyncio
@@ -34,15 +35,30 @@ _configure_onnx_threads()
 
 class AIService:
     """AI-powered image processing service"""
-    
-    REMBG_MODELS = ["u2net", "isnet-general-use", "u2net_human_seg", "silueta"]
-    
+
+    # Exact identifiers verified from rembg 2.0.76 sessions/__init__.py.
+    # BiRefNet variants give sharper edges but are only practical on GPU.
+    REMBG_MODELS = [
+        "u2net",
+        "isnet-general-use",
+        "u2net_human_seg",
+        "silueta",
+        "birefnet-general",
+        "birefnet-general-lite",
+        "birefnet-portrait",
+        "birefnet-dis",
+        "birefnet-hrsod",
+        "birefnet-cod",
+        "birefnet-massive",
+    ]
+
     def __init__(self):
         self.temp_dir = Path(settings.temp_dir)
         self.temp_dir.mkdir(parents=True, exist_ok=True)
         self._rembg_available = None
         self._sessions: dict = {}
-    
+        self._gpu_active: Optional[bool] = None
+
     async def is_available(self) -> bool:
         """Check if rembg is available"""
         if self._rembg_available is None:
@@ -54,21 +70,76 @@ class AIService:
                 logger.error(f"rembg not available: {e}")
                 self._rembg_available = False
         return self._rembg_available
-    
+
+    def _resolve_providers(self):
+        """
+        Decide ONNX execution providers. Honors settings.force_cpu and
+        settings.gpu_enabled, verifies CUDA is actually present in onnxruntime,
+        and always appends CPUExecutionProvider for graceful fallback.
+        Result cached in self._gpu_active.
+        """
+        if self._gpu_active is None:
+            self._gpu_active = False
+
+            if settings.force_cpu:
+                logger.info("FORCE_CPU set — using CPUExecutionProvider only")
+            elif not settings.gpu_enabled:
+                logger.info("GPU_ENABLED is false — CPU-only, using CPUExecutionProvider")
+            else:
+                try:
+                    import onnxruntime as ort
+                    available = ort.get_available_providers()
+                    logger.info(f"onnxruntime available providers: {available}")
+                    if "CUDAExecutionProvider" in available:
+                        self._gpu_active = True
+                        logger.info("CUDAExecutionProvider available — GPU acceleration ON")
+                    else:
+                        logger.warning(
+                            "GPU_ENABLED=true but CUDAExecutionProvider not available. "
+                            "Check onnxruntime-gpu install and CUDA 12 + cuDNN 9. "
+                            "Falling back to CPU."
+                        )
+                except Exception as e:
+                    logger.error(f"Provider detection failed, falling back to CPU: {e}")
+
+        if self._gpu_active:
+            cuda_opts = {
+                "device_id": 0,
+                "arena_extend_strategy": "kNextPowerOfTwo",
+                "gpu_mem_limit": int(settings.cuda_gpu_mem_limit),
+                "cudnn_conv_algo_search": "HEURISTIC",
+                "do_copy_in_default_stream": True,
+            }
+            return [("CUDAExecutionProvider", cuda_opts), "CPUExecutionProvider"]
+
+        return ["CPUExecutionProvider"]
+
+    def _default_model(self) -> str:
+        """On GPU prefer BiRefNet; on CPU respect configured default."""
+        if self._gpu_active:
+            return "birefnet-general"
+        return settings.rembg_model
+
     def _get_session(self, model: Optional[str] = None):
         """Get or create a rembg session for the given model (cached per-model)."""
-        model = model or settings.rembg_model
+        providers = self._resolve_providers()  # sets self._gpu_active
+        model = model or self._default_model()
         if model not in self._sessions:
             try:
                 from rembg import new_session
-                logger.info(f"Creating rembg session with model: {model}")
-                self._sessions[model] = new_session(model)
+                logger.info(
+                    f"Creating rembg session: model={model}, "
+                    f"providers={[p[0] if isinstance(p, tuple) else p for p in providers]}"
+                )
+                # rembg 2.0.76: new_session(model, **kwargs) forwards `providers`
+                # to BaseSession, which honors an explicit list.
+                self._sessions[model] = new_session(model, providers=providers)
                 logger.info(f"Session created successfully for model: {model}")
             except Exception as e:
                 logger.error(f"Failed to create session for {model}: {e}")
                 raise
         return self._sessions[model]
-    
+
     async def remove_background(
         self,
         input_path: str,
@@ -78,26 +149,27 @@ class AIService:
         **kwargs
     ) -> str:
         """Remove background from image using AI (rembg)"""
-        
-        model = model or settings.rembg_model
-        
+
+        self._resolve_providers()
+        model = model or self._default_model()
+
         logger.info(f"=== REMOVE BACKGROUND START ===")
         logger.info(f"Input: {input_path}")
-        logger.info(f"Model: {model}, Alpha matting: {alpha_matting}")
-        
+        logger.info(f"Model: {model}, Alpha matting: {alpha_matting}, GPU: {self._gpu_active}")
+
         if output_path is None:
             output_name = f"nobg_{uuid.uuid4().hex}.png"
             output_path = str(self.temp_dir / output_name)
-        
+
         logger.info(f"Output: {output_path}")
-        
+
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        
+
         if not Path(input_path).exists():
             raise FileNotFoundError(f"Input file not found: {input_path}")
-        
+
         logger.info(f"Input file size: {Path(input_path).stat().st_size} bytes")
-        
+
         try:
             import pymatting  # noqa: F401
             has_pymatting = True
@@ -105,38 +177,38 @@ class AIService:
         except ImportError:
             has_pymatting = False
             logger.warning("pymatting not available, alpha matting disabled")
-        
+
         use_alpha = alpha_matting and has_pymatting
         max_size = int(settings.rembg_max_size)
         timeout = int(settings.imagemagick_timeout)
-        
+
         def _process():
             """Synchronous processing"""
             try:
                 from PIL import Image
                 from rembg import remove
-                
+
                 logger.info("Loading image with PIL...")
                 img = Image.open(input_path)
                 original_size = img.size
                 logger.info(f"Image loaded: {img.size}, mode={img.mode}")
-                
+
                 if img.mode not in ('RGB', 'RGBA'):
                     img = img.convert('RGB')
                     logger.info(f"Converted to RGB")
-                
+
                 scale_factor = 1.0
                 if max(img.size) > max_size:
                     scale_factor = max_size / max(img.size)
                     new_size = (int(img.width * scale_factor), int(img.height * scale_factor))
                     img = img.resize(new_size, Image.Resampling.LANCZOS)
                     logger.info(f"Resized to: {new_size}")
-                
+
                 logger.info("Getting rembg session...")
                 session = self._get_session(model)
-                
+
                 logger.info(f"Calling rembg.remove() with alpha_matting={use_alpha}...")
-                
+
                 if use_alpha:
                     result = remove(
                         img,
@@ -154,26 +226,26 @@ class AIService:
                         alpha_matting=False,
                         post_process_mask=True,
                     )
-                
+
                 logger.info(f"Remove complete, result size: {result.size}, mode: {result.mode}")
-                
+
                 if scale_factor < 1.0:
                     result = result.resize(original_size, Image.Resampling.LANCZOS)
                     logger.info(f"Scaled back to: {original_size}")
-                
+
                 if result.mode != 'RGBA':
                     result = result.convert('RGBA')
-                
+
                 logger.info(f"Saving to {output_path}...")
                 result.save(output_path, 'PNG')
                 logger.info("Saved successfully")
-                
+
                 return output_path
-                
+
             except Exception as e:
                 logger.exception(f"Error in _process: {e}")
                 raise
-        
+
         try:
             loop = asyncio.get_running_loop()
             result = await asyncio.wait_for(
@@ -188,7 +260,7 @@ class AIService:
         except Exception as e:
             logger.exception(f"=== REMOVE BACKGROUND ERROR: {e} ===")
             raise
-    
+
     async def upscale(
         self,
         input_path: str,
@@ -197,26 +269,26 @@ class AIService:
         method: Literal["lanczos", "esrgan"] = "lanczos",
     ) -> str:
         """Upscale image resolution"""
-        
+
         logger.info(f"Upscale: {input_path}, scale={scale}")
-        
+
         if output_path is None:
             ext = Path(input_path).suffix or '.png'
             output_name = f"upscale_{scale}x_{uuid.uuid4().hex}{ext}"
             output_path = str(self.temp_dir / output_name)
-        
+
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        
+
         def _upscale():
             from PIL import Image, ImageFilter
-            
+
             with Image.open(input_path) as img:
                 new_size = (img.width * scale, img.height * scale)
                 logger.info(f"Upscaling: {img.size} -> {new_size}")
-                
+
                 result = img.resize(new_size, Image.Resampling.LANCZOS)
                 result = result.filter(ImageFilter.UnsharpMask(radius=1, percent=50, threshold=3))
-                
+
                 if output_path.lower().endswith('.png'):
                     result.save(output_path, 'PNG')
                 elif output_path.lower().endswith('.webp'):
@@ -225,9 +297,9 @@ class AIService:
                     if result.mode == 'RGBA':
                         result = result.convert('RGB')
                     result.save(output_path, 'JPEG', quality=95)
-                
+
                 return output_path
-        
+
         try:
             loop = asyncio.get_running_loop()
             return await asyncio.wait_for(
@@ -237,10 +309,10 @@ class AIService:
         except Exception as e:
             logger.exception(f"Upscale error: {e}")
             raise
-    
+
     async def get_available_models(self) -> list:
         return self.REMBG_MODELS
-    
+
     async def get_capabilities(self) -> dict:
         """Report available AI capabilities and current configuration."""
         available = await self.is_available()
@@ -249,51 +321,72 @@ class AIService:
             alpha_matting_available = True
         except ImportError:
             alpha_matting_available = False
+
+        self._resolve_providers()
+
         return {
             "background_removal": available,
             "upscale": True,
             "available_models": self.REMBG_MODELS,
-            "default_model": settings.rembg_model,
+            "default_model": self._default_model(),
             "alpha_matting_available": alpha_matting_available,
             "loaded_models": list(self._sessions.keys()),
             "max_size": settings.rembg_max_size,
+            "gpu_enabled": settings.gpu_enabled,
+            "gpu_active": bool(self._gpu_active),
         }
-    
+
     async def diagnose(self) -> dict:
         """Diagnostic info about AI service"""
         info = {
             "rembg_available": False,
             "pymatting_available": False,
             "sessions_loaded": list(self._sessions.keys()),
-            "default_model": settings.rembg_model,
+            "default_model": self._default_model(),
             "onnx_threads": settings.onnx_threads,
+            "gpu_enabled_setting": settings.gpu_enabled,
+            "force_cpu_setting": settings.force_cpu,
+            "gpu_active": None,
+            "onnx_providers": [],
+            "onnx_device": None,
             "u2net_home": os.environ.get("U2NET_HOME", "not set"),
             "home": os.environ.get("HOME", "not set"),
             "models_dir_exists": False,
             "models_found": [],
             "error": None,
         }
-        
+
         try:
             import rembg
             info["rembg_available"] = True
             info["rembg_version"] = getattr(rembg, "__version__", "unknown")
         except ImportError as e:
             info["error"] = f"rembg import error: {e}"
-        
+
         try:
             import pymatting  # noqa: F401
             info["pymatting_available"] = True
         except ImportError:
             pass
-        
+
+        try:
+            import onnxruntime as ort
+            info["onnx_providers"] = ort.get_available_providers()
+            info["onnx_device"] = ort.get_device()
+            info["onnxruntime_version"] = getattr(ort, "__version__", "unknown")
+        except Exception as e:
+            info["error"] = (info["error"] or "") + f" | onnxruntime: {e}"
+
+        self._resolve_providers()
+        info["gpu_active"] = bool(self._gpu_active)
+
         u2net_home = os.environ.get("U2NET_HOME", os.path.expanduser("~/.u2net"))
         info["u2net_home"] = u2net_home
-        
+
         if Path(u2net_home).exists():
             info["models_dir_exists"] = True
             info["models_found"] = [str(p) for p in Path(u2net_home).glob("*.onnx")]
-        
+
         return info
 
 

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -106,10 +106,16 @@ class AIService:
             cuda_opts = {
                 "device_id": 0,
                 "arena_extend_strategy": "kNextPowerOfTwo",
-                "gpu_mem_limit": int(settings.cuda_gpu_mem_limit),
                 "cudnn_conv_algo_search": "HEURISTIC",
                 "do_copy_in_default_stream": True,
             }
+            # Only cap arena memory if a positive limit is configured. 0 (default)
+            # lets onnxruntime grow the GPU arena dynamically up to whatever the
+            # card has — needed for large models like BiRefNet. A too-low fixed
+            # limit causes "Available memory of 0 is smaller than requested bytes".
+            mem_limit = int(settings.cuda_gpu_mem_limit)
+            if mem_limit > 0:
+                cuda_opts["gpu_mem_limit"] = mem_limit
             return [("CUDAExecutionProvider", cuda_opts), "CPUExecutionProvider"]
 
         return ["CPUExecutionProvider"]

--- a/backend/requirements-gpu.txt
+++ b/backend/requirements-gpu.txt
@@ -1,0 +1,43 @@
+# === GPU variant of requirements.txt ===
+# ONLY difference vs CPU: onnxruntime -> onnxruntime-gpu (CUDA 12.x default).
+# Keep every other pin in sync with requirements.txt.
+
+fastapi>=0.110.0,<1.0.0
+uvicorn[standard]>=0.27.0,<1.0.0
+python-multipart>=0.0.32,<1.0.0
+python-jose[cryptography]>=3.5.0,<4.0.0
+bcrypt>=4.0.0,<5.0.0
+
+httpx>=0.27.0,<1.0.0
+
+sqlalchemy[asyncio]>=2.0.51,<3.0.0
+asyncpg>=0.31.0,<1.0.0
+alembic>=1.13.0,<2.0.0
+
+redis>=7.4.0,<8.0.0
+rq>=1.16.0,<3.0.0
+
+pydantic>=2.6.0,<3.0.0
+pydantic-settings>=2.1.0,<3.0.0
+email-validator>=2.1.0,<3.0.0
+
+Wand>=0.7.1,<1.0.0
+
+aiofiles>=23.2.0,<26.0.0
+python-magic>=0.4.27,<1.0.0
+Pillow>=10.2.0,<13.0.0
+
+# AI Background Removal — GPU
+rembg>=2.0.76,<2.0.77
+onnxruntime-gpu>=1.16.0,<1.25.0
+pymatting>=1.1.15,<2.0.0
+scipy>=1.11.0,<2.0.0
+
+slowapi>=0.1.10,<1.0.0
+limits>=3.7.0,<6.0.0
+
+pytest>=7.4.0,<10.0.0
+pytest-asyncio>=0.23.0,<1.4.0
+
+python-dotenv>=1.0.0,<2.0.0
+orjson>=3.9.0,<4.0.0

--- a/backend/tests/test_ai_gpu.py
+++ b/backend/tests/test_ai_gpu.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for GPU provider resolution in AIService.
+
+No real GPU required. The config is driven via environment variables and a
+module reload (the supported way to configure pydantic-settings), and a fake
+onnxruntime module is injected so CUDA availability can be simulated anywhere,
+including CI runners without a GPU.
+"""
+
+import sys
+import types
+import importlib
+
+import pytest
+
+
+def _make_service(monkeypatch, *, gpu_enabled, force_cpu, cuda_present):
+    """Build a fresh AIService with config + onnxruntime simulated via env/reload."""
+    monkeypatch.setenv("GPU_ENABLED", "true" if gpu_enabled else "false")
+    monkeypatch.setenv("FORCE_CPU", "true" if force_cpu else "false")
+
+    from app.core import config
+    importlib.reload(config)
+
+    fake_ort = types.ModuleType("onnxruntime")
+    providers = ["CPUExecutionProvider"]
+    if cuda_present:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    fake_ort.get_available_providers = lambda: providers
+    fake_ort.get_device = lambda: "GPU" if cuda_present else "CPU"
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+    from app.services import ai_service as ai_mod
+    importlib.reload(ai_mod)
+    return ai_mod.AIService()
+
+
+def test_cpu_only_when_gpu_disabled(monkeypatch):
+    svc = _make_service(monkeypatch, gpu_enabled=False, force_cpu=False, cuda_present=True)
+    providers = svc._resolve_providers()
+    assert providers == ["CPUExecutionProvider"]
+    assert svc._gpu_active is False
+    assert svc._default_model() == "isnet-general-use"
+
+
+def test_force_cpu_overrides_gpu(monkeypatch):
+    svc = _make_service(monkeypatch, gpu_enabled=True, force_cpu=True, cuda_present=True)
+    providers = svc._resolve_providers()
+    assert providers == ["CPUExecutionProvider"]
+    assert svc._gpu_active is False
+
+
+def test_cuda_selected_with_cpu_fallback(monkeypatch):
+    svc = _make_service(monkeypatch, gpu_enabled=True, force_cpu=False, cuda_present=True)
+    providers = svc._resolve_providers()
+    assert providers[0][0] == "CUDAExecutionProvider"
+    assert providers[0][1]["gpu_mem_limit"] == 2 * 1024 * 1024 * 1024
+    assert providers[-1] == "CPUExecutionProvider"
+    assert svc._gpu_active is True
+    assert svc._default_model() == "birefnet-general"
+
+
+def test_gpu_enabled_but_cuda_missing_falls_back(monkeypatch):
+    svc = _make_service(monkeypatch, gpu_enabled=True, force_cpu=False, cuda_present=False)
+    providers = svc._resolve_providers()
+    assert providers == ["CPUExecutionProvider"]
+    assert svc._gpu_active is False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,74 @@ services:
           memory: 4G
           cpus: '2'
 
+  # GPU variant (v1.1.0). Run with: docker compose --profile gpu up --build
+  # Requires NVIDIA Container Toolkit on the host
+  # Shares postgres/redis/volumes with the CPU "app" service. Do not run both
+  # at once unless you change the ports below (same 3000/8000 by design).
+  app-gpu:
+    profiles: ["gpu"]
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        NEXT_PUBLIC_API_PORT: "${NEXT_PUBLIC_API_PORT:-8000}"
+    image: imagemagick-webui:latest-gpu
+    runtime: nvidia
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+      - "${BACKEND_PORT:-8000}:8000"
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=production
+      - NEXT_PUBLIC_API_PORT=${NEXT_PUBLIC_API_PORT:-8000}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
+      - DATABASE_URL=${DATABASE_URL:-postgresql+asyncpg://imagemagick:imagemagick@postgres:5432/imagemagick}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+      - SECRET_KEY=${SECRET_KEY:-CHANGE_THIS_supersecretkey_production_abc123}
+      - JWT_SECRET=${JWT_SECRET:-CHANGE_THIS_jwt_secret_production_xyz789}
+      - REQUIRE_LOGIN=${REQUIRE_LOGIN:-true}
+      - ALLOW_REGISTRATION=${ALLOW_REGISTRATION:-true}
+      - DEFAULT_OUTPUT_FORMAT=${DEFAULT_OUTPUT_FORMAT:-webp}
+      - DEFAULT_QUALITY=${DEFAULT_QUALITY:-85}
+      - MAX_UPLOAD_SIZE_MB=${MAX_UPLOAD_SIZE_MB:-100}
+      - IMAGEMAGICK_TIMEOUT=${IMAGEMAGICK_TIMEOUT:-300}
+      - IMAGEMAGICK_MEMORY_LIMIT=${IMAGEMAGICK_MEMORY_LIMIT:-2GB}
+      - HISTORY_RETENTION_HOURS=${HISTORY_RETENTION_HOURS:-24}
+      - REMBG_MODEL=${REMBG_MODEL:-isnet-general-use}
+      - ONNX_THREADS=${ONNX_THREADS:-0}
+      - TZ=${TZ:-UTC}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+      - GPU_ENABLED=true
+      - FORCE_CPU=${FORCE_CPU:-false}
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    volumes:
+      - uploads:/app/uploads
+      - processed:/app/processed
+      - temp:/tmp/imagemagick
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
   postgres:
     image: postgres:16-alpine
     environment:


### PR DESCRIPTION
Adds optional GPU acceleration for rembg background removal.

- Separate `latest-gpu` image (Dockerfile.gpu, CUDA 12 + cuDNN 9 base);
  CPU `latest` image unchanged.
- AIService selects CUDAExecutionProvider with CPU fallback; honors
  GPU_ENABLED and FORCE_CPU env vars.
- BiRefNet models added as selectable options (sharper edges, GPU-only practical).
- New app-gpu compose service behind the `gpu` profile.
- 4 unit tests for provider resolution.

Tested: CPU regression verified end-to-end (container healthy, ai-status
reports gpu_active=false on CPU image). GPU build + real inference NOT yet
run on hardware - to be validated before tagging v1.1.0.