### PR TITLE
fix(security): prevent path traversal via output_format (CWE-22)

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -4,7 +4,7 @@ Operations API for image processing
 
 import os
 import shlex
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Literal
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -58,6 +58,10 @@ def validate_path(file_path: str) -> str:
     return abs_path
 
 
+# Allowed output formats (whitelist prevents path traversal via format string)
+OutputFormat = Literal["webp", "jpg", "jpeg", "png", "avif"]
+
+
 # Request models
 class ResizeParams(BaseModel):
     width: Optional[int] = None
@@ -96,19 +100,19 @@ class Operation(BaseModel):
 class ProcessRequest(BaseModel):
     image_ids: List[int]
     operations: List[Operation]
-    output_format: str = "webp"
+    output_format: OutputFormat = "webp"
     quality: int = Field(85, ge=1, le=100)
 
 
 class RawCommandRequest(BaseModel):
     image_ids: List[int]
     command: str
-    output_format: str = "png"
+    output_format: OutputFormat = "png"
 
 
 class PreviewCommandRequest(BaseModel):
     operations: List[Operation]
-    output_format: str = "webp"
+    output_format: OutputFormat = "webp"
     quality: int = 85
 
 
@@ -418,7 +422,7 @@ class LivePreviewRequest(BaseModel):
 
 class RemoveBackgroundRequest(BaseModel):
     image_ids: List[int]
-    output_format: str = "png"
+    output_format: OutputFormat = "png"
     alpha_matting: bool = False
 
 
@@ -831,7 +835,7 @@ async def get_ai_capabilities():
 class ProcessSyncRequest(BaseModel):
     image_id: int
     operations: List[Operation]
-    output_format: str = "jpg"
+    output_format: OutputFormat = "jpg"
 
 
 @router.post("/process-sync")
@@ -979,7 +983,7 @@ async def process_sync(
 class DownloadDirectRequest(BaseModel):
     image_id: int
     operations: List[Operation]
-    output_format: str = "webp"
+    output_format: OutputFormat = "webp"
     quality: int = 85
 
 

--- a/backend/app/services/file_service.py
+++ b/backend/app/services/file_service.py
@@ -3,6 +3,7 @@ File handling service for uploads and downloads
 """
 
 import os
+import re
 import uuid
 import zipfile
 import aiofiles
@@ -200,6 +201,35 @@ class FileService:
         
         return count
     
+    # Whitelist of output formats. Anything else is rejected outright, which
+    # prevents a crafted format string from escaping the processed directory.
+    ALLOWED_OUTPUT_FORMATS = frozenset({
+        "webp", "jpg", "jpeg", "png", "avif", "gif", "tiff", "bmp",
+    })
+
+    @staticmethod
+    def _safe_stem(filename: str) -> str:
+        """Reduce an arbitrary filename to a safe stem with no path components."""
+        stem = Path(Path(filename).name).stem
+        stem = re.sub(r"[^A-Za-z0-9_-]", "_", stem)
+        return stem[:100] or "file"
+
+    @classmethod
+    def _safe_format(cls, format: str) -> str:
+        """Reject any output format outside the whitelist."""
+        fmt = str(format).strip().lower().lstrip(".")
+        if fmt not in cls.ALLOWED_OUTPUT_FORMATS:
+            raise ValueError(f"Unsupported output format: {format!r}")
+        return fmt
+
+    def _ensure_within(self, candidate: Path, root: Path) -> str:
+        """Final guard: the fully resolved path must stay inside root."""
+        resolved = os.path.realpath(str(candidate))
+        root_resolved = os.path.realpath(str(root))
+        if not (resolved == root_resolved or resolved.startswith(root_resolved + os.sep)):
+            raise ValueError("Resolved path escapes the allowed directory")
+        return resolved
+
     def get_output_path(
         self,
         filename: str,
@@ -207,17 +237,18 @@ class FileService:
         user_id: Optional[int] = None
     ) -> str:
         """Generate output path for processed file"""
-        base_name = Path(filename).stem
-        output_name = f"{base_name}_{uuid.uuid4().hex[:8]}.{format}"
-        
+        base_name = self._safe_stem(filename)
+        fmt = self._safe_format(format)
+        output_name = f"{base_name}_{uuid.uuid4().hex[:8]}.{fmt}"
+
         if user_id:
             output_dir = self.processed_dir / str(user_id)
         else:
             output_dir = self.processed_dir / "anonymous"
-        
+
         output_dir.mkdir(parents=True, exist_ok=True)
-        
-        return str(output_dir / output_name)
+
+        return self._ensure_within(output_dir / output_name, self.processed_dir)
     
     async def get_processed_path(
         self,
@@ -225,23 +256,26 @@ class FileService:
         user_id: Optional[int] = None
     ) -> str:
         """Generate output path for AI processed file (async version)"""
-        # Extract base name and extension
-        path = Path(filename)
-        base = path.stem
-        ext = path.suffix if path.suffix else '.png'
-        
+        base = self._safe_stem(filename)
+
+        raw_ext = Path(Path(filename).name).suffix.lstrip(".").lower()
+        try:
+            ext = self._safe_format(raw_ext)
+        except ValueError:
+            ext = "png"
+
         # ALWAYS add unique suffix to prevent duplicates
         unique_id = uuid.uuid4().hex[:8]
-        output_name = f"{base}_{unique_id}{ext}"
-        
+        output_name = f"{base}_{unique_id}.{ext}"
+
         if user_id:
             output_dir = self.processed_dir / str(user_id)
         else:
             output_dir = self.processed_dir / "anonymous"
-        
+
         output_dir.mkdir(parents=True, exist_ok=True)
-        
-        return str(output_dir / output_name)
+
+        return self._ensure_within(output_dir / output_name, self.processed_dir)
 
 
 # Singleton instance

--- a/backend/tests/test_path_traversal.py
+++ b/backend/tests/test_path_traversal.py
@@ -1,0 +1,62 @@
+"""
+Regression tests for CWE-22 path traversal in output path generation.
+
+Before this fix, `output_format` came straight from the request body and was
+interpolated into the output filename, so a value like
+"png/../../../../etc/cron.d/x" could place a file anywhere the process could
+write. Both the format whitelist and the resolved-path guard must stay in place.
+"""
+
+import pytest
+
+from app.services.file_service import file_service
+
+
+TRAVERSAL_FORMATS = [
+    "png/../../../../etc/cron.d/x",
+    "../../../../etc/passwd",
+    "png/../../..",
+    "/etc/passwd",
+    "png\x00.sh",
+    "exe",
+    "",
+]
+
+VALID_FORMATS = ["webp", "jpg", "jpeg", "png", "avif"]
+
+
+@pytest.mark.parametrize("bad_format", TRAVERSAL_FORMATS)
+def test_get_output_path_rejects_unsafe_format(bad_format):
+    with pytest.raises(ValueError):
+        file_service.get_output_path("photo.jpg", bad_format, user_id=1)
+
+
+@pytest.mark.parametrize("good_format", VALID_FORMATS)
+def test_get_output_path_accepts_whitelisted_format(good_format):
+    result = file_service.get_output_path("photo.jpg", good_format, user_id=1)
+    assert result.endswith(f".{good_format}")
+
+
+def test_get_output_path_stays_inside_processed_dir():
+    root = str(file_service.processed_dir.resolve())
+    result = file_service.get_output_path("photo.jpg", "webp", user_id=1)
+    assert result.startswith(root)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../../etc/passwd", "foo/../bar.png", "../../../evil.jpg"],
+)
+def test_get_output_path_strips_path_components_from_filename(filename):
+    root = str(file_service.processed_dir.resolve())
+    result = file_service.get_output_path(filename, "png", user_id=1)
+    assert result.startswith(root)
+    assert ".." not in result
+
+
+@pytest.mark.asyncio
+async def test_get_processed_path_falls_back_to_png_for_unsafe_extension():
+    root = str(file_service.processed_dir.resolve())
+    result = await file_service.get_processed_path("evil.sh", user_id=1)
+    assert result.startswith(root)
+    assert result.endswith(".png")


### PR DESCRIPTION
The output_format field came straight from the request body as a plain str and was interpolated into the output filename in FileService.get_output_path, so a value such as 'png/../../../../etc/cron.d/x' could place a file outside the processed directory. Input paths were guarded by validate_path, but output paths were not. Three layers of defence: output_format is now a Literal whitelist in every Pydantic request model; get_output_path and get_processed_path sanitise the filename stem and reject formats outside a whitelist; both anchor the final path with realpath and verify it stays inside processed_dir. Adds tests/test_path_traversal.py covering the traversal vectors, the whitelist, and the containment guard.