### PR TITLE
ci: run the backend test suite on every push and pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# The suite only needs to read the code it is testing.
+permissions:
+  contents: read
+
 jobs:
   backend:
     name: Backend tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install system libraries
+        # libmagic backs `import magic`; ImageMagick backs Wand.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libmagic1 imagemagick
+
+      - name: Install Python dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        working-directory: backend
+        # Slow tests download and run AI models; they are not appropriate for CI.
+        env:
+          UPLOAD_DIR: /tmp/ci/uploads
+          PROCESSED_DIR: /tmp/ci/processed
+          TEMP_DIR: /tmp/ci/temp
+        run: pytest -v -m "not slow"

--- a/backend/tests/test_ai_gpu.py
+++ b/backend/tests/test_ai_gpu.py
@@ -14,10 +14,11 @@ import importlib
 import pytest
 
 
-def _make_service(monkeypatch, *, gpu_enabled, force_cpu, cuda_present):
+def _make_service(monkeypatch, *, gpu_enabled, force_cpu, cuda_present, mem_limit=0):
     """Build a fresh AIService with config + onnxruntime simulated via env/reload."""
     monkeypatch.setenv("GPU_ENABLED", "true" if gpu_enabled else "false")
     monkeypatch.setenv("FORCE_CPU", "true" if force_cpu else "false")
+    monkeypatch.setenv("CUDA_GPU_MEM_LIMIT", str(mem_limit))
 
     from app.core import config
     importlib.reload(config)
@@ -54,10 +55,33 @@ def test_cuda_selected_with_cpu_fallback(monkeypatch):
     svc = _make_service(monkeypatch, gpu_enabled=True, force_cpu=False, cuda_present=True)
     providers = svc._resolve_providers()
     assert providers[0][0] == "CUDAExecutionProvider"
-    assert providers[0][1]["gpu_mem_limit"] == 2 * 1024 * 1024 * 1024
     assert providers[-1] == "CPUExecutionProvider"
     assert svc._gpu_active is True
     assert svc._default_model() == "birefnet-general"
+
+
+def test_no_gpu_mem_limit_by_default(monkeypatch):
+    """
+    With CUDA_GPU_MEM_LIMIT at its default of 0 the arena must be left uncapped,
+    so onnxruntime can grow it to fit large models such as BiRefNet. Setting a
+    fixed cap here previously caused "Available memory of 0 is smaller than
+    requested bytes".
+    """
+    svc = _make_service(
+        monkeypatch, gpu_enabled=True, force_cpu=False, cuda_present=True, mem_limit=0
+    )
+    cuda_opts = svc._resolve_providers()[0][1]
+    assert "gpu_mem_limit" not in cuda_opts
+
+
+def test_gpu_mem_limit_applied_when_configured(monkeypatch):
+    """A positive CUDA_GPU_MEM_LIMIT must be passed through to the provider."""
+    limit = 2 * 1024 * 1024 * 1024
+    svc = _make_service(
+        monkeypatch, gpu_enabled=True, force_cpu=False, cuda_present=True, mem_limit=limit
+    )
+    cuda_opts = svc._resolve_providers()[0][1]
+    assert cuda_opts["gpu_mem_limit"] == limit
 
 
 def test_gpu_enabled_but_cuda_missing_falls_back(monkeypatch):


### PR DESCRIPTION
The only workflow so far built and published the Docker images, so the 40-odd tests under backend/tests were never run outside a developer's machine. Adds .github/workflows/tests.yml, which installs libmagic and ImageMagick, installs backend/requirements.txt, and runs pytest with the slow AI-model tests deselected. Also fixes test_cuda_selected_with_cpu_fallback, which asserted a hard 2 GB gpu_mem_limit that _resolve_providers deliberately stopped setting: with CUDA_GPU_MEM_LIMIT at its default of 0 the arena is left uncapped so large models such as BiRefNet can grow into it. The assertion is replaced by two tests covering both branches, so CI starts out green.