### PR TITLE
refactor(security): centralise path validation in app.core.paths

### DIFF
--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -19,6 +19,7 @@ import re
 from app.core.database import get_db
 from app.core.security import get_current_user, get_current_user_or_enforce, get_current_user_optional, get_current_user_optional
 from app.core.config import settings
+from app.core.paths import validate_path
 from app.models.user import User
 from app.models.image import Image
 from app.services.file_service import file_service
@@ -28,41 +29,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# Security: Path validation
-ALLOWED_DIRS = [
-    os.path.realpath(settings.upload_dir),
-    os.path.realpath(settings.processed_dir),
-    os.path.realpath(settings.temp_dir),
-    '/app/uploads',
-    '/app/processed',
-    '/tmp'
-]
-
-
-def validate_path(file_path: str) -> str:
-    """
-    Validate that a file path is within allowed directories.
-    Prevents path traversal attacks.
-    Returns the validated absolute path or raises HTTPException.
-    """
-    if not file_path:
-        raise HTTPException(status_code=400, detail="Invalid file path")
-    
-    # Resolve to absolute path
-    abs_path = os.path.realpath(file_path)
-    
-    # Check if path is within allowed directories
-    is_allowed = any(
-        abs_path.startswith(os.path.realpath(allowed_dir))
-        for allowed_dir in ALLOWED_DIRS
-        if allowed_dir and os.path.exists(os.path.dirname(allowed_dir) or '/')
-    )
-    
-    if not is_allowed:
-        logger.warning(f"Path traversal attempt blocked: {file_path} -> {abs_path}")
-        raise HTTPException(status_code=403, detail="Access denied")
-    
-    return abs_path
 
 
 # Response models

--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -15,6 +15,7 @@ import uuid
 from app.core.database import get_db
 from app.core.security import get_current_user_or_enforce
 from app.core.config import settings
+from app.core.paths import validate_path
 from app.models.user import User
 from app.models.image import Image
 from app.models.job import Job, JobStatus
@@ -25,37 +26,6 @@ from app.workers.tasks import process_images, process_raw_command
 router = APIRouter()
 
 
-# Security: Path validation
-ALLOWED_DIRS = [
-    os.path.realpath(settings.upload_dir),
-    os.path.realpath(settings.processed_dir),
-    os.path.realpath(settings.temp_dir),
-    '/app/uploads',
-    '/app/processed',
-    '/tmp'
-]
-
-
-def validate_path(file_path: str) -> str:
-    """
-    Validate that a file path is within allowed directories.
-    Prevents path traversal attacks.
-    """
-    if not file_path:
-        raise HTTPException(status_code=400, detail="Invalid file path")
-    
-    abs_path = os.path.realpath(file_path)
-    
-    is_allowed = any(
-        abs_path.startswith(os.path.realpath(allowed_dir))
-        for allowed_dir in ALLOWED_DIRS
-        if allowed_dir and os.path.exists(os.path.dirname(allowed_dir) or '/')
-    )
-    
-    if not is_allowed:
-        raise HTTPException(status_code=403, detail="Access denied")
-    
-    return abs_path
 
 
 # Allowed output formats (whitelist prevents path traversal via format string)
@@ -1004,7 +974,6 @@ async def download_direct(
     from pathlib import Path
     from fastapi.responses import FileResponse
     from app.services.file_service import file_service
-    import tempfile
     
     user_id = current_user.id if current_user else None
     
@@ -1029,7 +998,11 @@ async def download_direct(
     output_filename = f"edited_{original_name}.{actual_output_format}"
     
     temp_filename = f"download_{uuid.uuid4().hex}.{actual_output_format}"
-    output_path = os.path.join(tempfile.gettempdir(), temp_filename)
+    # settings.temp_dir rather than tempfile.gettempdir(): the download lands
+    # inside the directory the cleanup job sweeps, and /tmp at large no longer
+    # needs to sit on the path whitelist.
+    os.makedirs(settings.temp_dir, exist_ok=True)
+    output_path = os.path.join(settings.temp_dir, temp_filename)
 
     validated_output_path = validate_path(output_path)
     

--- a/backend/app/core/paths.py
+++ b/backend/app/core/paths.py
@@ -1,0 +1,56 @@
+"""
+Single source of truth for filesystem path validation.
+
+Both the images and operations APIs previously carried their own copy of
+ALLOWED_DIRS and validate_path. Two copies of a security control is one copy
+too many: a fix applied to one is easy to forget in the other.
+"""
+
+import logging
+import os
+from typing import List
+
+from fastapi import HTTPException
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _allowed_dirs() -> List[str]:
+    """
+    Directories the application is permitted to read from and write to.
+
+    Resolved on every call rather than cached at import time, so tests (and
+    anything else that reconfigures settings) see the current values.
+    """
+    return [
+        os.path.realpath(settings.upload_dir),
+        os.path.realpath(settings.processed_dir),
+        os.path.realpath(settings.temp_dir),
+    ]
+
+
+def validate_path(file_path: str) -> str:
+    """
+    Resolve a path and confirm it lies inside an allowed directory.
+
+    Returns the resolved absolute path, or raises HTTPException. Note the
+    separator in the prefix comparison: without it, "/app/uploads_evil" would
+    pass a check against "/app/uploads".
+    """
+    if not file_path:
+        raise HTTPException(status_code=400, detail="Invalid file path")
+
+    abs_path = os.path.realpath(file_path)
+
+    is_allowed = any(
+        abs_path == allowed or abs_path.startswith(allowed + os.sep)
+        for allowed in _allowed_dirs()
+    )
+
+    if not is_allowed:
+        logger.warning(f"Path traversal attempt blocked: {file_path} -> {abs_path}")
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    return abs_path

--- a/backend/tests/test_ai_and_security.py
+++ b/backend/tests/test_ai_and_security.py
@@ -40,11 +40,17 @@ class TestPathValidation:
     
     def test_accepts_allowed_dir(self):
         """A path inside an allowed dir must pass and return a realpath"""
-        from app.api.operations import validate_path
-        
-        result = validate_path("/tmp/some_generated_file.png")
+        import os
+
+        from app.core.config import settings
+        from app.core.paths import validate_path
+
+        # settings.temp_dir, not bare /tmp: the whitelist covers the directories
+        # the app actually owns, so an unrelated file in /tmp is now rejected.
+        target = os.path.join(settings.temp_dir, "some_generated_file.png")
+        result = validate_path(target)
         assert isinstance(result, str)
-        assert result.startswith("/tmp")
+        assert result == os.path.realpath(target)
 
 
 class TestAIConfiguration:

--- a/backend/tests/test_path_validation.py
+++ b/backend/tests/test_path_validation.py
@@ -1,0 +1,76 @@
+"""
+Tests for the centralised path validation in app.core.paths.
+
+Two things this guards that the previous per-module copies did not:
+  - the prefix comparison now requires a separator, so a sibling directory
+    whose name merely starts with an allowed one ("/data/uploads_evil" against
+    "/data/uploads") is rejected;
+  - /tmp at large is no longer whitelisted, only settings.temp_dir.
+"""
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.config import settings
+from app.core.paths import validate_path
+
+
+def test_rejects_empty_path():
+    with pytest.raises(HTTPException) as exc:
+        validate_path("")
+    assert exc.value.status_code == 400
+
+
+def test_accepts_path_inside_upload_dir():
+    target = os.path.join(settings.upload_dir, "1", "photo.jpg")
+    assert validate_path(target) == os.path.realpath(target)
+
+
+def test_accepts_path_inside_processed_dir():
+    target = os.path.join(settings.processed_dir, "1", "photo.webp")
+    assert validate_path(target) == os.path.realpath(target)
+
+
+def test_accepts_path_inside_temp_dir():
+    target = os.path.join(settings.temp_dir, "download_abc.png")
+    assert validate_path(target) == os.path.realpath(target)
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "/etc/passwd",
+        "/root/.ssh/id_rsa",
+        "../../etc/shadow",
+    ],
+)
+def test_rejects_paths_outside_allowed_dirs(hostile):
+    with pytest.raises(HTTPException) as exc:
+        validate_path(hostile)
+    assert exc.value.status_code == 403
+
+
+def test_rejects_traversal_out_of_upload_dir():
+    escape = os.path.join(settings.upload_dir, "..", "..", "etc", "passwd")
+    with pytest.raises(HTTPException) as exc:
+        validate_path(escape)
+    assert exc.value.status_code == 403
+
+
+def test_rejects_sibling_directory_sharing_a_prefix():
+    """"/data/uploads_evil" must not pass a check against "/data/uploads"."""
+    sibling = os.path.realpath(settings.upload_dir) + "_evil/file.jpg"
+    with pytest.raises(HTTPException) as exc:
+        validate_path(sibling)
+    assert exc.value.status_code == 403
+
+
+def test_bare_tmp_is_no_longer_allowed():
+    """Only settings.temp_dir is whitelisted, not the whole of /tmp."""
+    if os.path.realpath(settings.temp_dir) == "/tmp":
+        pytest.skip("temp_dir is /tmp in this configuration")
+    with pytest.raises(HTTPException) as exc:
+        validate_path("/tmp/somebody_elses_file.png")
+    assert exc.value.status_code == 403


### PR DESCRIPTION
validate_path and ALLOWED_DIRS existed as two byte-identical copies, one in the images API and one in the operations API. Two copies of a security control is one copy too many: a fix applied to one is easy to forget in the other. Both now import from app.core.paths. Two weaknesses are fixed in the process. The prefix comparison required no separator, so a sibling directory whose name merely starts with an allowed one (/app/uploads_evil against /app/uploads) would have passed. And the whitelist included bare /tmp, a world-writable directory, alongside hardcoded /app/uploads and /app/processed that duplicated what settings already provided; the whitelist is now just the three directories the application owns. The download endpoint wrote its temporary file via tempfile.gettempdir(), which lands in /tmp rather than settings.temp_dir, and was the only reason /tmp had to be whitelisted at all. It now writes to settings.temp_dir, which also means the cleanup job actually sweeps those files. Adds tests/test_path_validation.py covering the allowed directories, traversal attempts, the sibling-prefix case, and the narrowed /tmp rule.